### PR TITLE
feat: add achievements, updater and startup options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to this project will be documented here.
 - Optional `--test`, `--debug` and `--silent` modes for development and automation.
 - Command-line interface with task selection and log export.
 
+## [0.2.0] - 2024-xx-xx
+### Added
+- Autostart toggle with registry integration.
+- Local achievement tracking and gallery window.
+- Remote log delivery via configurable webhook.
+- GitHub release checker with download prompt.
+- Splash screen and experimental `.gbln` project format.
+
 ## [0.1.0] - 2024-xx-xx
 ### Added
 - Initial project structure with source and documentation directories.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,10 @@ Windows clean-up commands into a friendly interface.
 - SFC, DISM and CHKDSK checks
 - Temp file cleanup and drive optimisation
 - Toggleable logs and exportable reports
+- Optional run-at-startup toggle
+- Hidden achievement system and gallery
+- Remote log delivery via webhook
+- Automatic update checks against GitHub releases
 
 ## Download
 [Download MaintenanceGoblin.exe](https://github.com/yourname/maintenance-goblin/releases/latest/download/MaintenanceGoblin.exe)

--- a/installer.nsi
+++ b/installer.nsi
@@ -1,0 +1,56 @@
+; Maintenance Goblin NSIS installer
+!define APP_NAME "Maintenance Goblin"
+!define APP_VERSION "0.2.0"
+
+OutFile "MaintenanceGoblinSetup.exe"
+InstallDir "$PROGRAMFILES32\Maintenance Goblin"
+RequestExecutionLevel admin
+
+!include "MUI2.nsh"
+!define MUI_ICON "goblin.ico"
+!define MUI_HEADERIMAGE
+!define MUI_FINISHPAGE_RUN
+!define MUI_FINISHPAGE_RUN_FUNCTION LaunchApp
+
+Var StartOnBoot
+
+Page directory
+Page instfiles
+Page custom StartOnBootPage StartOnBootPageLeave
+!insertmacro MUI_LANGUAGE "English"
+
+Section "Install"
+  SetOutPath "$INSTDIR"
+  File "dist\MaintenanceGoblin.exe"
+  WriteUninstaller "$INSTDIR\Uninstall.exe"
+  CreateShortcut "$DESKTOP\Maintenance Goblin.lnk" "$INSTDIR\MaintenanceGoblin.exe"
+  CreateDirectory "$SMPROGRAMS\Maintenance Goblin"
+  CreateShortcut "$SMPROGRAMS\Maintenance Goblin\Maintenance Goblin.lnk" "$INSTDIR\MaintenanceGoblin.exe"
+SectionEnd
+
+Section -post
+  ${If} $StartOnBoot == 1
+    WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "${APP_NAME}" '"$INSTDIR\MaintenanceGoblin.exe" --silent'
+  ${EndIf}
+SectionEnd
+
+Function StartOnBootPage
+  nsDialogs::Create 1018
+  Pop $0
+  ${If} $0 == error
+    Abort
+  ${EndIf}
+  ${NSD_CreateCheckbox} 0 0 100% 12u "Launch at startup"
+  Pop $StartOnBoot
+  nsDialogs::Show
+FunctionEnd
+
+Function StartOnBootPageLeave
+  ${NSD_GetState} $StartOnBoot $StartOnBoot
+FunctionEnd
+
+Function LaunchApp
+  Exec "$INSTDIR\MaintenanceGoblin.exe"
+FunctionEnd
+
+SilentInstall silent

--- a/src/achievements.py
+++ b/src/achievements.py
@@ -1,0 +1,94 @@
+"""Simple local achievement tracking for Maintenance Goblin."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+try:  # pragma: no cover - optional
+    import winsound
+except Exception:  # pragma: no cover - platform fallback
+    winsound = None  # type: ignore
+
+from .config_manager import load_json, save_json
+
+FILE_NAME = "achievements.json"
+DEFAULT_DATA: Dict[str, object] = {
+    "counts": {},
+    "unlocked": [],
+    "sound": True,
+    "total_runs": 0,
+}
+
+ACHIEVEMENT_DEFS = [
+    {"id": "first_summon", "name": "\U0001f9d9\ufe0f First Summon", "check": lambda d: d["total_runs"] >= 1},
+    {
+        "id": "weekly_ritual",
+        "name": "\U0001f4c5 Weekly Ritual Master",
+        "check": lambda d: d["total_runs"] >= 7,
+    },
+    {
+        "id": "dism_overkill",
+        "name": "\U0001f480 Overkill: Ran DISM 10x",
+        "check": lambda d: d["counts"].get("DISM Health Restore", 0) >= 10,
+    },
+]
+
+
+def _load() -> Dict[str, object]:
+    return load_json(FILE_NAME, DEFAULT_DATA)
+
+
+def _save(data: Dict[str, object]) -> None:
+    save_json(FILE_NAME, data)
+
+
+def record(task_label: str) -> List[str]:
+    """Record execution of ``task_label`` and return newly unlocked names."""
+
+    data = _load()
+    counts: Dict[str, int] = data.setdefault("counts", {})  # type: ignore
+    counts[task_label] = counts.get(task_label, 0) + 1
+    data["total_runs"] = int(data.get("total_runs", 0)) + 1
+    unlocked: List[str] = list(data.get("unlocked", []))
+
+    newly: List[str] = []
+    for ach in ACHIEVEMENT_DEFS:
+        if ach["id"] in unlocked:
+            continue
+        if ach["check"](data):  # type: ignore[arg-type]
+            unlocked.append(ach["id"])
+            newly.append(ach["name"])
+            if data.get("sound", True) and winsound:
+                try:
+                    winsound.MessageBeep()  # type: ignore[attr-defined]
+                except Exception:
+                    pass
+    data["unlocked"] = unlocked
+    _save(data)
+    return newly
+
+
+def get_unlocked() -> List[str]:
+    data = _load()
+    return [a["name"] for a in ACHIEVEMENT_DEFS if a["id"] in data.get("unlocked", [])]
+
+
+def toggle_sound(enable: bool) -> None:
+    data = _load()
+    data["sound"] = bool(enable)
+    _save(data)
+
+
+def show_gallery(parent=None) -> None:
+    import tkinter as tk
+    from tkinter import ttk
+
+    badges = get_unlocked()
+    win = tk.Toplevel(parent)
+    win.title("Goblin Gallery")
+    ttk.Label(win, text="Achievements", font=("Segoe UI", 12, "bold")).pack(padx=10, pady=10)
+    if not badges:
+        ttk.Label(win, text="No achievements yet").pack(padx=10, pady=10)
+    for b in badges:
+        ttk.Label(win, text=b).pack(anchor="w", padx=10)
+    ttk.Button(win, text="Close", command=win.destroy).pack(pady=10)

--- a/src/autostart.py
+++ b/src/autostart.py
@@ -1,0 +1,45 @@
+"""Utilities to manage automatic start-up behaviour on Windows."""
+
+import os
+import sys
+
+if os.name == "nt":  # pragma: no cover - Windows specific
+    import winreg
+
+APP_NAME = "Maintenance Goblin"
+RUN_KEY = r"Software\\Microsoft\\Windows\\CurrentVersion\\Run"
+
+
+def enable_autostart() -> None:
+    """Register the application to run on user login."""
+
+    if os.name != "nt":
+        return
+    path = sys.executable if getattr(sys, "frozen", False) else os.path.abspath(sys.argv[0])
+    with winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_KEY, 0, winreg.KEY_SET_VALUE) as key:
+        winreg.SetValueEx(key, APP_NAME, 0, winreg.REG_SZ, f'"{path}" --silent')
+
+
+def disable_autostart() -> None:
+    """Remove start-up registration if present."""
+
+    if os.name != "nt":
+        return
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_KEY, 0, winreg.KEY_SET_VALUE) as key:
+            winreg.DeleteValue(key, APP_NAME)
+    except OSError:
+        pass
+
+
+def is_enabled() -> bool:
+    """Return ``True`` if start-up registration exists."""
+
+    if os.name != "nt":
+        return False
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_KEY) as key:
+            winreg.QueryValueEx(key, APP_NAME)
+        return True
+    except OSError:
+        return False

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -1,0 +1,27 @@
+import json
+import os
+from typing import Any, Dict
+
+APP_DIR = os.path.join(os.getenv("APPDATA", os.path.expanduser("~")), "MaintenanceGoblin")
+CONFIG_DIR = os.path.join(APP_DIR, "config")
+
+
+def load_json(name: str, default: Dict[str, Any]) -> Dict[str, Any]:
+    """Load ``name`` from ``CONFIG_DIR`` returning ``default`` on error."""
+
+    path = os.path.join(CONFIG_DIR, name)
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (FileNotFoundError, json.JSONDecodeError):
+        data = default.copy()
+    return data
+
+
+def save_json(name: str, data: Dict[str, Any]) -> None:
+    """Persist ``data`` as JSON under ``CONFIG_DIR``."""
+
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+    path = os.path.join(CONFIG_DIR, name)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)

--- a/src/log_delivery.py
+++ b/src/log_delivery.py
@@ -1,0 +1,30 @@
+"""Optional remote log delivery integrations."""
+
+from __future__ import annotations
+
+import urllib.request
+from typing import Optional
+
+from .config_manager import load_json
+
+SETTINGS_FILE = "settings.json"
+DEFAULT_SETTINGS = {"remote_log": {"url": ""}}
+
+
+def get_settings() -> dict:
+    return load_json(SETTINGS_FILE, DEFAULT_SETTINGS)
+
+
+def send_log(text: str) -> None:
+    """Send ``text`` to configured webhook if present."""
+
+    settings = get_settings().get("remote_log", {})
+    url: Optional[str] = settings.get("url")
+    if not url:
+        return
+    data = text.encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers={"Content-Type": "text/plain"})
+    try:  # pragma: no cover - network optional
+        urllib.request.urlopen(req, timeout=5)
+    except Exception:
+        pass

--- a/src/maintenance_goblin.py
+++ b/src/maintenance_goblin.py
@@ -29,11 +29,17 @@ import ttkbootstrap as ttkb
 from ttkbootstrap import ttk
 from ttkbootstrap.scrolled import ScrolledText
 
+import achievements
+import autostart
+import log_delivery
+import updater
+from config_manager import load_json, save_json
+
 __all__ = ["__version__", "main"]
 
 
 # Semantic version of the application
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 APP_NAME = "Maintenance Goblin"
 BASE_DIR = getattr(sys, "_MEIPASS", os.path.abspath(os.path.dirname(__file__)))
@@ -43,6 +49,8 @@ APP_DIR = os.path.join(
     os.getenv("APPDATA", os.path.expanduser("~")), "MaintenanceGoblin"
 )
 LOG_DIR = os.path.join(APP_DIR, "logs")
+
+SETTINGS = load_json("settings.json", {"autostart": False, "remote_log": {"url": ""}})
 
 TEST_MODE = False
 DEBUG_MODE = False
@@ -183,11 +191,15 @@ def run_task(task: Task, ui: Dict[str, tk.Widget]) -> None:
         else:
             log_message(log_widget, fake_output)
         log_message(log_widget, f"✅ {task.label} completed.")
+        for name in achievements.record(task.label):
+            log_message(log_widget, f"Achievement unlocked: {name}")
         return
 
     if task.func:
         task.func(log_widget)
         log_message(log_widget, f"✅ {task.label} completed.")
+        for name in achievements.record(task.label):
+            log_message(log_widget, f"Achievement unlocked: {name}")
         return
 
     try:
@@ -205,6 +217,8 @@ def run_task(task: Task, ui: Dict[str, tk.Widget]) -> None:
         else:
             log_message(log_widget, result.stdout.strip() or "[No Output]")
         log_message(log_widget, f"✅ {task.label} completed.")
+        for name in achievements.record(task.label):
+            log_message(log_widget, f"Achievement unlocked: {name}")
     except Exception as exc:  # pragma: no cover - defensive
         log_message(log_widget, f"❌ Error during {task.label}: {exc}")
 
@@ -319,6 +333,34 @@ def export_report(log_widget: tk.Text) -> None:
     with open(path, "w", encoding="utf-8") as fh:
         fh.write(text)
     log_message(log_widget, f"Report exported to {path}")
+    log_delivery.send_log(text)
+
+
+def show_update_dialog(ui: Dict[str, tk.Widget], latest: str, notes: str, url: str) -> None:
+    """Display release notes and a download link for an update."""
+
+    win = tk.Toplevel(ui["root"])
+    win.title("Update Available")
+    ttk.Label(win, text=f"Version {latest} is available", font=("Segoe UI", 11, "bold")).pack(
+        padx=10, pady=10
+    )
+    txt = ScrolledText(win, width=60, height=10)
+    txt.insert("end", notes or "No release notes")
+    txt.configure(state="disabled")
+    txt.pack(padx=10, pady=5)
+    ttk.Button(win, text="Download", command=lambda: updater.open_download(url)).pack(
+        pady=5
+    )
+
+
+def show_splash() -> None:
+    """Display a simple splash screen on startup."""
+
+    splash = tk.Tk()
+    splash.overrideredirect(True)
+    ttk.Label(splash, text="Summoning Goblin...", padding=20).pack()
+    splash.after(1500, splash.destroy)
+    splash.mainloop()
 
 
 def run_selected_tasks(ui: Dict[str, tk.Widget]) -> None:
@@ -425,7 +467,33 @@ def create_gui() -> ttkb.Window:
         buttons, text="Toggle Theme", command=lambda: toggle_theme(style)
     ).pack(side="left", padx=5)
 
+    autostart_var = tk.BooleanVar(
+        value=SETTINGS.get("autostart", False) or autostart.is_enabled()
+    )
+
+    def on_autostart() -> None:
+        if autostart_var.get():
+            autostart.enable_autostart()
+        else:
+            autostart.disable_autostart()
+        SETTINGS["autostart"] = autostart_var.get()
+        save_json("settings.json", SETTINGS)
+
+    ttk.Checkbutton(
+        buttons, text="Run at startup", variable=autostart_var, command=on_autostart
+    ).pack(side="left", padx=5)
+    ttk.Button(buttons, text="Gallery", command=lambda: achievements.show_gallery(root)).pack(
+        side="left", padx=5
+    )
+
     update_system_info(ui)
+
+    def update_cb(latest: Optional[str], notes: str, url: str) -> None:
+        if not latest:
+            return
+        root.after(0, lambda: show_update_dialog(ui, latest, notes, url))
+
+    updater.check_async(__version__, update_cb)
 
     return root
 
@@ -489,6 +557,8 @@ def main() -> None:
         return
 
     elevate()
+    if not SILENT_MODE:
+        show_splash()
     root = create_gui()
     root.mainloop()
 

--- a/src/project.py
+++ b/src/project.py
@@ -1,0 +1,21 @@
+"""Helpers for the experimental `.gbln` project file format."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def load_project(path: str | Path) -> Dict[str, Any]:
+    """Load ``path`` and return its JSON content."""
+
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def save_project(path: str | Path, data: Dict[str, Any]) -> None:
+    """Persist ``data`` to ``path`` in JSON format."""
+
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)

--- a/src/updater.py
+++ b/src/updater.py
@@ -1,0 +1,47 @@
+"""Check GitHub releases to determine if an update is available."""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.request
+import webbrowser
+from typing import Callable, Optional
+
+REPO = "yourname/maintenance-goblin"
+
+
+def fetch_latest_version() -> tuple[str, str, str]:
+    """Return (version, notes, url) for the latest release."""
+
+    with urllib.request.urlopen(
+        f"https://api.github.com/repos/{REPO}/releases/latest", timeout=5
+    ) as resp:
+        data = json.load(resp)
+    version = data.get("tag_name", "").lstrip("v")
+    notes = data.get("body", "")
+    url = data.get("html_url", "")
+    return version, notes, url
+
+
+def check_async(current: str, callback: Callable[[Optional[str], str, str], None]) -> None:
+    """Check for updates in a background thread and invoke ``callback``."""
+
+    def worker() -> None:
+        try:  # pragma: no cover - network optional
+            latest, notes, url = fetch_latest_version()
+            if latest and latest != current:
+                callback(latest, notes, url)
+            else:
+                callback(None, "", "")
+        except Exception:
+            callback(None, "", "")
+
+    threading.Thread(target=worker, daemon=True).start()
+
+
+def open_download(url: str) -> None:
+    try:  # pragma: no cover - defensive
+        webbrowser.open(url)
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
- add Windows autostart helpers, update checker and splash screen
- introduce hidden achievements system and remote log webhook
- provide NSIS installer script and `.gbln` project helpers

## Testing
- `python -m py_compile $(git ls-files 'src/*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6893f7d0b07483298d98ecd80faf8f7c