### PR TITLE
Fix module imports for standalone execution

### DIFF
--- a/src/achievements.py
+++ b/src/achievements.py
@@ -9,7 +9,7 @@ try:  # pragma: no cover - optional
 except Exception:  # pragma: no cover - platform fallback
     winsound = None  # type: ignore
 
-from .config_manager import load_json, save_json
+from config_manager import load_json, save_json
 
 FILE_NAME = "achievements.json"
 DEFAULT_DATA: Dict[str, object] = {

--- a/src/log_delivery.py
+++ b/src/log_delivery.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import urllib.request
 from typing import Optional
 
-from .config_manager import load_json
+from config_manager import load_json
 
 SETTINGS_FILE = "settings.json"
 DEFAULT_SETTINGS = {"remote_log": {"url": ""}}


### PR DESCRIPTION
## Summary
- fix relative imports in achievements and log_delivery modules
- allow maintenance_goblin to run as a script

## Testing
- `python src/maintenance_goblin.py --test --cli --run-all`


------
https://chatgpt.com/codex/tasks/task_e_6893faaf8d048329bf88c5ebdac91598