### PR TITLE
Fix module imports for standalone execution

### DIFF
--- a/src/achievements.py
+++ b/src/achievements.py
@@ -9,7 +9,7 @@ try:  # pragma: no cover - optional
 except Exception:  # pragma: no cover - platform fallback
     winsound = None  # type: ignore
 
-from .config_manager import load_json, save_json
+from config_manager import load_json, save_json
 
 FILE_NAME = "achievements.json"
 DEFAULT_DATA: Dict[str, object] = {

--- a/src/log_delivery.py
+++ b/src/log_delivery.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import urllib.request
 from typing import Optional
 
-from .config_manager import load_json
+from config_manager import load_json
 
 SETTINGS_FILE = "settings.json"
 DEFAULT_SETTINGS = {"remote_log": {"url": ""}}

--- a/src/maintenance_goblin.py
+++ b/src/maintenance_goblin.py
@@ -355,8 +355,10 @@ def show_update_dialog(ui: Dict[str, tk.Widget], latest: str, notes: str, url: s
 
 def show_splash() -> None:
     """Display a simple splash screen on startup."""
-
-    splash = tk.Tk()
+    try:
+        splash = tk.Tk()
+    except tk.TclError:  # pragma: no cover - headless environments
+        return
     splash.overrideredirect(True)
     ttk.Label(splash, text="Summoning Goblin...", padding=20).pack()
     splash.after(1500, splash.destroy)


### PR DESCRIPTION
## Summary
- fix relative imports in achievements and log_delivery modules
- allow maintenance_goblin to run as a script
- gracefully skip splash screen when no display is available

## Testing
- `python src/maintenance_goblin.py --test --cli --run-all`


------
https://chatgpt.com/codex/tasks/task_e_6893faaf8d048329bf88c5ebdac91598