### PR TITLE
Fix root window instantiation

### DIFF
--- a/src/maintenance_goblin.py
+++ b/src/maintenance_goblin.py
@@ -564,7 +564,7 @@ def main() -> None:
     if not SILENT_MODE:
         show_splash()
 
-    root = ttk.Window(title=APP_NAME, themename="darkly")
+    root = ttkb.Window(title=APP_NAME, themename="darkly")
     create_gui(root)
     root.mainloop()
 


### PR DESCRIPTION
## Summary
- Use ttkbootstrap's Window for root GUI creation to avoid tkinter attribute error

## Testing
- `python -m py_compile src/maintenance_goblin.py`
- `pytest -q`
- `python src/maintenance_goblin.py --test --cli --run-all`


------
https://chatgpt.com/codex/tasks/task_e_6894a2df936483298a359a773006c873