### PR TITLE
Prevent argparse crash in windowed build

### DIFF
--- a/src/maintenance_goblin.py
+++ b/src/maintenance_goblin.py
@@ -37,6 +37,18 @@ from config_manager import load_json, save_json
 
 __all__ = ["__version__", "main"]
 
+# When packaged with PyInstaller using the ``--windowed`` flag, ``sys.stdout``
+# and ``sys.stderr`` are ``None`` because there is no attached console.  The
+# :mod:`argparse` module expects these streams to be writable when displaying
+# usage or error messages.  If either stream is ``None`` it will raise
+# ``AttributeError`` when attempting to call ``write``.  To avoid crashing when
+# the application is executed as a GUI-only program, provide dummy file objects
+# that safely discard any output.
+if sys.stdout is None:  # pragma: no cover - relies on PyInstaller behaviour
+    sys.stdout = open(os.devnull, "w")
+if sys.stderr is None:  # pragma: no cover - relies on PyInstaller behaviour
+    sys.stderr = open(os.devnull, "w")
+
 
 # Semantic version of the application
 __version__ = "0.1.0"


### PR DESCRIPTION
## Summary
- Ensure stdout and stderr are available when the app is packaged without a console, avoiding argparse crashes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python src/maintenance_goblin.py --help > /tmp/help.txt && tail -n 20 /tmp/help.txt`


------
https://chatgpt.com/codex/tasks/task_e_689b3e0a6d408329a9d0a027c4a82f27