### PR TITLE
fix: ensure GUI launches after admin elevation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.1] - 2025-08-11
+### Fixed
+- Ensure elevated relaunch no longer passes the executable path as a parameter, allowing the GUI to open correctly.
+
 ## [0.1.0] - 2025-08-11
 ### Added
 - First public release: GUI with Run All, SFC, DISM, Temp cleanup, Disk Cleanup, Defrag

--- a/src/maintenance_goblin.py
+++ b/src/maintenance_goblin.py
@@ -51,7 +51,7 @@ if sys.stderr is None:  # pragma: no cover - relies on PyInstaller behaviour
 
 
 # Semantic version of the application
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 APP_NAME = "Maintenance Goblin"
 BASE_DIR = getattr(sys, "_MEIPASS", os.path.abspath(os.path.dirname(__file__)))
@@ -506,8 +506,11 @@ def main() -> None:
 
     if os.name == "nt" and not is_admin():
         print("Not admin. Relaunching...")
+        params = subprocess.list2cmdline(
+            sys.argv[1:] if getattr(sys, "frozen", False) else sys.argv
+        )
         ctypes.windll.shell32.ShellExecuteW(
-            None, "runas", sys.executable, " ".join(sys.argv), None, 1
+            None, "runas", sys.executable, params, None, 1
         )
         sys.exit()
 


### PR DESCRIPTION
## Summary
- fix Windows admin relaunch to pass only arguments, allowing GUI to start
- bump version to 0.1.1 and document change in changelog

## Testing
- `python -m py_compile src/maintenance_goblin.py`
- `python -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_689be8f7ea688329bfbaf9cdb81d41c0