### PR TITLE
Add optional test step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt pyinstaller
+      - name: Run tests
+        run: python -m unittest
+        continue-on-error: true
       - name: Build exe
         run: |
           pyinstaller --onefile --windowed --name "MaintenanceGoblin" ^


### PR DESCRIPTION
## Summary
- run unit tests during release workflow
- release workflow builds Windows executable and attaches it to a GitHub release

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_68bd8863736c83298a9bb73fc8f64aad